### PR TITLE
Create GET route for events by category

### DIFF
--- a/server/app.js
+++ b/server/app.js
@@ -14,6 +14,8 @@ app.get('/', (req, res) => {
 
 app.get('/api/events/:id', controller.getEventById);
 
+app.get('/api/categories/:id', controller.getEventsByCategory);
+
 let port = process.env.PORT || 3016;
 
 app.listen(port, function () {

--- a/server/controllers/index.js
+++ b/server/controllers/index.js
@@ -10,6 +10,17 @@ const getEventById = function (req, res) {
     });
 }
 
+const getEventsByCategory = function (req, res) {
+    models.getEventsByCategory(req.params.id, (err, data) => {
+        if (err) {
+            res.status(500).send({ error: err.message });
+        } else {
+            res.send(data);
+        }
+    })
+}
+
 module.exports = {
-    getEventById: getEventById
+    getEventById: getEventById,
+    getEventsByCategory: getEventsByCategory
 }

--- a/server/db/seed.test.js
+++ b/server/db/seed.test.js
@@ -2,10 +2,8 @@ const { db } = require('./');
 const app = require('../app');
 const request = require('supertest');
 
-// console.log('app loaded', app);
-
-describe('GET endpoint /api/events/:id', () => {
-    test(`should return data based on an event's ID`, () => {
+describe('GET route /api/events/:id', () => {
+    test(`should return an event based on its ID`, () => {
         return request(app)
             .get('/api/events/1')
             .then((res) => {
@@ -16,6 +14,19 @@ describe('GET endpoint /api/events/:id', () => {
                 expect(typeof res.body[0].name).toBe('string');
                 expect(typeof res.body[0].image_url).toBe('string');
                 expect(typeof res.body[0].category).toBe('number');
+            });
+    });
+});
+
+describe('GET route /api/categories/:id', () => {
+    test(`should return all events based on their category`, () => {
+        return request(app)
+            .get('/api/categories/1')
+            .then((res) => {
+                expect(Array.isArray(res.body)).toBe(true);
+                res.body.forEach(event => {
+                    expect(event.category).toBe(1);
+                });
             });
     });
 });

--- a/server/models/index.js
+++ b/server/models/index.js
@@ -12,6 +12,19 @@ const getEventById = function (id, callback) {
         });
 }
 
+const getEventsByCategory = function (id, callback) {
+    let statement = `SELECT * FROM event WHERE category = ${id}`;
+        db.all(statement, (err, data) => {
+            if (err) {
+                callback(err, null);
+            } else {
+                // db.close();
+                return callback(null, data);
+            }
+        });
+}
+
 module.exports = {
-    getEventById: getEventById
+    getEventById: getEventById,
+    getEventsByCategory: getEventsByCategory
 }


### PR DESCRIPTION
The GET route `/api/categories/:id` returns all events that have a category ID matching the params `:id`.

My plan is to create a React component, `<Category/>`, that makes HTTP requests to the GET route. `<Category/>` will then pass data from the route into multiple `<Event/>` components.