### PR TITLE
Add 'See All' link to <Category>

### DIFF
--- a/client/dist/styles.css
+++ b/client/dist/styles.css
@@ -1,15 +1,34 @@
 .category {
+    /* background-color: red; */
+    font-family: Arial,Tahoma,"Bitstream Vera Sans",sans-serif;
     padding: 12px;
     margin-left: 40px;
+    display: inline-block;
+}
+
+.category .title {
+    /* background-color: gray; */
+    padding-right: 12px;
 }
 
 .category .counter {
-    font-family: Arial,Tahoma,"Bitstream Vera Sans",sans-serif;
     font-size: 18px;
     color: #767676;
 }
 
+.category .seeall {
+    float: right;
+    font-size: 16px;
+    color: #4a4a4a;
+    text-decoration: none;
+}
+
+.seeall:hover {
+    text-decoration: underline;
+}
+
 .event {
+    /* background-color: aqua; */
     padding: 12px;
     width: 238px;
     height: 270px;

--- a/client/src/components/Category.jsx
+++ b/client/src/components/Category.jsx
@@ -57,7 +57,7 @@ class Category extends React.Component {
         
         return (
             <div className='category'>
-                <div>
+                <div style={{'width': 'max-content'}}>
                     <div className="title">
                         <a href="#" style={categoryStyle}>{this.state.category}</a>
                         {this.state.events.length > 0 ? <span className="counter">({this.state.events.length})</span> : ''}

--- a/client/src/components/Category.jsx
+++ b/client/src/components/Category.jsx
@@ -58,9 +58,10 @@ class Category extends React.Component {
         return (
             <div className='category'>
                 <div>
-                    <div>
+                    <div className="title">
                         <a href="#" style={categoryStyle}>{this.state.category}</a>
                         {this.state.events.length > 0 ? <span className="counter">({this.state.events.length})</span> : ''}
+                        <a href="#" className="seeall">See all</a>
                     </div>
                     {this.state.events.slice(0,4).map((event, index) => <Event props={event} key={index} />)}
                 </div>


### PR DESCRIPTION
Link stays above upper right corner of final <Event> within a <Category>.

Note: Link renders correctly on a laptop, but app hasn't been tested on a mobile device.

Trello ticket
[Add "See All" link to `<Category>`](https://trello.com/c/RytcqJQe)